### PR TITLE
Web Components are all generally be "stand-alone"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@
 ## Contents
 
 - [Element Extensions](#element-extensions)
+- [Button Elements](#button-elements)
 - [Custom Elements](#custom-elements)
 - [Novelty Elements](#novelty-elements)
 
@@ -26,6 +27,14 @@ Github has a bundle of elements that extend the native `<time>` element.
 - [`<local-time>`](https://github.com/github/time-elements)
 - [`<relative-time>`](https://github.com/github/time-elements)
 - [`<time-ago>`](https://github.com/github/time-elements)
+
+## Button Elements
+
+Drop-in button elements for use in your work.
+
+- [Lion Button](https://www.npmjs.com/package/@lion/button)
+- [Material Button](https://www.npmjs.com/package/@material/mwc-button)
+- [Spectrum Button](https://www.npmjs.com/package/@spectrum-web-components/button)
 
 ## Custom Elements
 


### PR DESCRIPTION
Upon review of the available element options, I think I have a better grasp of what the "original" intent for the words "stand-alone" is: single element repositories. This is pretty evident from the existing listings and their all being featured by their GitHub repo. In light of this, I present this PR to open a broader conversation into what represents a "stand-alone" element, and whether this list should be expanded on by way of single element NPM installs.

In that very few of the previously included elements are "vanilla" or "dependency-free", I've made a speculative addition of "Button Elements" and listed a handful of said elements that can be installed from NPM and used stand-alone without additional "cherry-picking". Like other elements herein, they rely on dependencies like `lit-element` and/or sibling packages in a greater project, but being web components do not require that they are "called" by a parent framework and therefore "framework-agnostic".

Thanks in advance for considering this PR. I can certainly understand if our definitions of "stand-alone" diverge, and would hope you take the opportunity to further outline your thoughts on a definition there to guide future PRs and issues if they do. If you're interested in my definition, I'd be happy to submit further PRs with similar expansions to the listings featured here.

Cheers!