### PR TITLE
Add `image-compare` web component

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,7 @@ Frequently-solved problems in web component form.
 - [`<tab-container>`](https://github.com/github/tab-container-element)
 - [`<task-lists>`](https://github.com/github/task-lists-element)
 - [`<two-up>`](https://github.com/GoogleChromeLabs/two-up)
+- [`<image-compare>`](https://image-compare-component.netlify.app/)
 - [`<dark-mode-toggle>`](https://github.com/GoogleChromeLabs/dark-mode-toggle)
 - [`<katex-display>` and `<katex-inline>`](https://www.npmjs.com/package/katex-elements)
 - [`<html-include>`](https://www.npmjs.com/package//html-include-element)


### PR DESCRIPTION
Hey @davatron5000 , I recently made the [image-compare web component](https://image-compare-component.netlify.app/) for a [blog post my boss wrote](https://cloudfour.com/thinks/a-bashful-button-worth-8-million/). 

I really like this repo and often use it when looking for a component to solve a common problem. I thought the `image-compare` component might be a good addition.

It's a standalone vanilla web component with zero dependencies that clocks in at [1.5kb minified and gzipped](https://bundlephobia.com/package/@cloudfour/image-compare@1.0.0). It's similar to `two-up` but I couldn't figure out how to control `two-up` using keyboard controls so I made `image-compare`. It uses an `input type="range"` under the hood to make it easy to control via keyboard, screen reader, etc. 

I noticed most of the components here link to a GitHub repo. I had made a [docs page](https://image-compare-component.netlify.app/) on Netlify for `image-compare` so used that as the link. Let me know if you'd prefer to link to the GitHub repo or would like me to make any other changes to this PR.

Let me know what you think! No hard feelings if this isn't a good fit for this list 🙂 

Thanks!