### PR TITLE
Switch to using Eleventy to build the README.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/submission.yaml
+++ b/.github/ISSUE_TEMPLATE/submission.yaml
@@ -25,7 +25,7 @@ body:
         - time
         - custom
         - novelty
-      default: extension
+      default: 0
   - type: input
     id: repo
     attributes:

--- a/.github/ISSUE_TEMPLATE/submission.yaml
+++ b/.github/ISSUE_TEMPLATE/submission.yaml
@@ -1,0 +1,52 @@
+name: Submission
+description: You would like to add a new standalone to the project
+title: "Submission: "
+labels: ["submission"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your submission! Want to save us time? Follow the [contributing guide](https://github.com/davatron5000/awesome-standalones/blob/master/contributing.md) and once approved we can merge it directly in. Alternatively follow the steps below.
+  - type: input
+    id: name
+    attributes:
+      label: Name
+      description: The name of your standalone, preferably the tag name (e.g. "play-button").
+      placeholder: standalone-name
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: The category your standalone falls into. If you don't think it fits into any please propose a new category via a pull request.
+      options:
+        - extension
+        - time
+        - custom
+        - novelty
+      default: extension
+  - type: input
+    id: repo
+    attributes:
+      label: Repo
+      description: The source code for the standalone, if it exists publically
+      placeholder: https://github.com/daviddarnes/play-button
+  - type: input
+    id: url
+    attributes:
+      label: URL
+      description: A main page for the standalone (homepage, post, demo, etc)
+      placeholder: https://darn.es/play-button-web-component/
+  - type: input
+    id: script
+    attributes:
+      label: Install script
+      description: The advisted method of installing the standalone in a web project
+      placeholder: npm install @daviddarnes/play-button
+  - type: textarea
+    id: snippet
+    attributes:
+      label: Snippet example
+      description: An example snippet of HTML to demonstate how to use the component
+      render: html

--- a/.github/ISSUE_TEMPLATE/update.yaml
+++ b/.github/ISSUE_TEMPLATE/update.yaml
@@ -1,0 +1,37 @@
+name: Update
+description: You would like to update an existing standalone
+title: "Update: "
+labels: ["update"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Want to save time? Find your standalone in [the main JSON file](https://github.com/davatron5000/awesome-standalones/blob/main/src/_data/standalones.json) and update it directly with a pull request. Don't forget to check our [contributing guide](https://github.com/davatron5000/awesome-standalones/blob/master/contributing.md).
+  - type: input
+    id: name
+    attributes:
+      label: Name
+      description: The name of your standalone
+      placeholder: standalone-name
+    validations:
+      required: true
+  - type: dropdown
+    id: attributes
+    attributes:
+      label: Attribute(s)
+      description: The attribute(s) you'd like to change.
+      multiple: true
+      options:
+        - name
+        - category
+        - repo
+        - url
+        - script
+        - snippet
+    validations:
+      required: true
+  - type: textarea
+    id: Changes
+    attributes:
+      label: Changes
+      description: The changes you'd like to make

--- a/.github/ISSUE_TEMPLATE/update.yaml
+++ b/.github/ISSUE_TEMPLATE/update.yaml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Want to save time? Find your standalone in [the main JSON file](https://github.com/davatron5000/awesome-standalones/blob/main/src/_data/standalones.json) and update it directly with a pull request. Don't forget to check our [contributing guide](https://github.com/davatron5000/awesome-standalones/blob/master/contributing.md).
+        Want to save time? Find your standalone in [the main JSON file](https://github.com/davatron5000/awesome-standalones/blob/main/src/_data/standalones.json) and update it directly with a pull request. Don't forget to check our [contributing guide](https://github.com/davatron5000/awesome-standalones/blob/main/contributing.md).
   - type: input
     id: name
     attributes:

--- a/.github/workflows/update-readme.yaml
+++ b/.github/workflows/update-readme.yaml
@@ -1,0 +1,26 @@
+name: Update readme.md
+
+on: push
+
+jobs:
+  format-code:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      # Run eleventy to build the readme.md
+      - run: cd src && npx @11ty/eleventy --output=../ && cd ../
+
+      # Commit all changed files back to the repository
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          # Optional. Commit message for the created commit.
+          commit_message: Update readme.md

--- a/contributing.md
+++ b/contributing.md
@@ -8,10 +8,20 @@ project you agree to abide by its terms.
 
 Ensure your pull request adheres to the following guidelines:
 
-- Link should look like this:  
-    ```
-    [`<element-name>`](http://url-of-repo)
-    ```
+- Items should be added like this:
+  ```json
+  {
+    "name": "play-button",
+    "category": "extension",
+    "repo": "https://github.com/daviddarnes/play-button",
+    "url": "https://darn.es/play-button-web-component/",
+    "script": "npm install @daviddarnes/play-button",
+    "snippet": "<play-button><button>Play me</button><audio src='...'></audio></play-button>"
+  }
+  ```
+- Items should always have a `name`, `category` and `repo`
+- `category` can be `extension`, `time`, `custom` or `novelty`
+- `url`, `script` and `snippet` are optional
 - If it's a significant change, please file an issue to discuss first
 - And don't forget to check other PRs for duplicates
 

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ Web Components that extend or add to an existing semantic element.
 - [`<details-dialog>`](https://github.com/github/details-dialog-element)
 - [`<details-menu>`](https://github.com/github/details-menu-element)
 - [`<file-drop>`](https://github.com/GoogleChromeLabs/file-drop)
+- [`<play-button>`](https://github.com/daviddarnes/play-button)
 
 ## `<time>` Elements
 

--- a/readme.md
+++ b/readme.md
@@ -2,14 +2,6 @@
 
 > A curated list of awesome framework-agnostic standalone web components
 
-
-## Contents
-
-- [Element Extensions](#element-extensions)
-- [Custom Elements](#custom-elements)
-- [Novelty Elements](#novelty-elements)
-
-
 ## Element Extensions
 
 Web Components that extend or add to an existing semantic element.
@@ -18,8 +10,7 @@ Web Components that extend or add to an existing semantic element.
 - [`<details-menu>`](https://github.com/github/details-menu-element)
 - [`<file-drop>`](https://github.com/GoogleChromeLabs/file-drop)
 
-
-### `<time>` Elements
+## `<time>` Elements
 
 Github has a bundle of elements that extend the native `<time>` element.
 
@@ -40,8 +31,8 @@ Frequently-solved problems in web component form.
 - [`<tab-container>`](https://github.com/github/tab-container-element)
 - [`<task-lists>`](https://github.com/github/task-lists-element)
 - [`<two-up>`](https://github.com/GoogleChromeLabs/two-up)
-- [`<dark-mode-toggle>`](https://github.com/GoogleChromeLabs/dark-mode-toggle)
-- [`<katex-display>` and `<katex-inline>`](https://www.npmjs.com/package/katex-elements)
+- [`<dark-mode>`](https://github.com/GoogleChromeLabs/dark-mode-toggle)
+- [`<katex-display>`](https://www.npmjs.com/package/katex-elements)
 - [`<html-include>`](https://www.npmjs.com/package//html-include-element)
 - [`<pwa-install>`](https://github.com/pwa-builder/pwa-install)
 - [`<l-i>`](https://github.com/lekoala/last-icon)

--- a/src/_data/standalones.json
+++ b/src/_data/standalones.json
@@ -1,0 +1,107 @@
+[
+  {
+    "name": "details-dialog",
+    "category": "extension",
+    "repo": "https://github.com/github/details-dialog-element"
+  },
+  {
+    "name": "details-menu",
+    "category": "extension",
+    "repo": "https://github.com/github/details-menu-element"
+  },
+  {
+    "name": "file-drop",
+    "category": "extension",
+    "repo": "https://github.com/GoogleChromeLabs/file-drop"
+  },
+  {
+    "name": "local-time",
+    "category": "time",
+    "repo": "https://github.com/github/time-elements"
+  },
+  {
+    "name": "relative-time",
+    "category": "time",
+    "repo": "https://github.com/github/time-elements"
+  },
+  {
+    "name": "time-ago",
+    "category": "time",
+    "repo": "https://github.com/github/time-elements"
+  },
+  {
+    "name": "clipboard-copy",
+    "category": "custom",
+    "repo": "https://github.com/github/clipboard-copy-element"
+  },
+  {
+    "name": "input-knob",
+    "category": "custom",
+    "repo": "https://github.com/GoogleChromeLabs/input-knob"
+  },
+  {
+    "name": "lite-youtube",
+    "category": "custom",
+    "repo": "https://github.com/paulirish/lite-youtube-embed"
+  },
+  {
+    "name": "model-viewer",
+    "category": "custom",
+    "repo": "https://github.com/GoogleWebComponents/model-viewer"
+  },
+  {
+    "name": "pinch-zoom",
+    "category": "custom",
+    "repo": "https://github.com/GoogleChromeLabs/pinch-zoom"
+  },
+  {
+    "name": "range-slider",
+    "category": "custom",
+    "repo": "https://github.com/andreruffert/range-slider-element"
+  },
+  {
+    "name": "tab-container",
+    "category": "custom",
+    "repo": "https://github.com/github/tab-container-element"
+  },
+  {
+    "name": "task-lists",
+    "category": "custom",
+    "repo": "https://github.com/github/task-lists-element"
+  },
+  {
+    "name": "two-up",
+    "category": "custom",
+    "repo": "https://github.com/GoogleChromeLabs/two-up"
+  },
+  {
+    "name": "dark-mode",
+    "category": "custom",
+    "repo": "https://github.com/GoogleChromeLabs/dark-mode-toggle"
+  },
+  {
+    "name": "katex-display",
+    "category": "custom",
+    "repo": "https://www.npmjs.com/package/katex-elements"
+  },
+  {
+    "name": "html-include",
+    "category": "custom",
+    "repo": "https://www.npmjs.com/package//html-include-element"
+  },
+  {
+    "name": "pwa-install",
+    "category": "custom",
+    "repo": "https://github.com/pwa-builder/pwa-install"
+  },
+  {
+    "name": "l-i",
+    "category": "custom",
+    "repo": "https://github.com/lekoala/last-icon"
+  },
+  {
+    "name": "spacer-gif",
+    "category": "novelty",
+    "repo": "https://github.com/erikkroes/spacer-gif"
+  }
+]

--- a/src/_data/standalones.json
+++ b/src/_data/standalones.json
@@ -103,5 +103,13 @@
     "name": "spacer-gif",
     "category": "novelty",
     "repo": "https://github.com/erikkroes/spacer-gif"
+  },
+  {
+    "name": "play-button",
+    "category": "extension",
+    "repo": "https://github.com/daviddarnes/play-button",
+    "url": "https://darn.es/play-button-web-component/",
+    "script": "npm install @daviddarnes/play-button",
+    "snippet": "<play-button><button>Play me</button><audio src='...'></audio></play-button>"
   }
 ]

--- a/src/readme.njk
+++ b/src/readme.njk
@@ -1,0 +1,45 @@
+---
+permalink: /readme.md
+---
+# Awesome Standalones [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+
+> A curated list of awesome framework-agnostic standalone web components
+
+## Element Extensions
+
+Web Components that extend or add to an existing semantic element.
+{% for tag in standalones %}{% if tag.category == 'extension' %}
+- [`<{{ tag.name }}>`]({{ tag.repo }})
+{%- endif %}{% endfor %}
+
+## `<time>` Elements
+
+Github has a bundle of elements that extend the native `<time>` element.
+{% for tag in standalones %}{% if tag.category == 'time' %}
+- [`<{{ tag.name }}>`]({{ tag.repo }})
+{%- endif %}{% endfor %}
+
+## Custom Elements
+
+Frequently-solved problems in web component form.
+{% for tag in standalones %}{% if tag.category == 'custom' %}
+- [`<{{ tag.name }}>`]({{ tag.repo }})
+{%- endif %}{% endfor %}
+
+## Novelty Elements
+{% for tag in standalones %}{% if tag.category == 'novelty' %}
+- [`<{{ tag.name }}>`]({{ tag.repo }})
+{%- endif %}{% endfor %}
+
+## Contribute
+
+Contributions welcome! Read the [contribution guidelines](contributing.md) first.
+
+Thanks @simevidas for prompting the idea.
+
+## License
+
+[![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0)
+
+To the extent possible under law, Dave Rupert has waived all copyright and
+related or neighboring rights to this work.


### PR DESCRIPTION
## Summary
In order to make maintaining this repo easier I propose we switch to accepting submissions as a JSON object added to a main `standalones.json`. We can then use a build tool, in this case Eleventy, to build the main `README.md` file. Submissions can then be supplied as a clean JSON object.

This allows us to make the submissions process more streamlined. People submitting can either create an issue with the JSON object in the description, or directly add the object to the `standalones.json` file. Plus we can automate the build step using GitHub Actions. It's actually possible to automate file updates to the repo using the `github/checkout` action. You can see an example here https://github.com/orgs/community/discussions/25234#discussioncomment-7976290

## Next steps
Next I need to create a Workflow file which will contain the GitHub Action to rebuild the `README.md`. I'll need some tokens for verification which we can do later. Once that's all working and we've tested the submission process (just add a JSON object to the `standalones.json` and magic should happen ✨) we can then switch to this `main` branch. I saw that the existing branch is called `master`. Since I'll be setting up the GitHub Action with a branch called `main` anyway I thought it was a good moment to get inline with the current naming conventions. It's the reason this PR is actually a draft, the idea isn't to merge the branch but to make it the new main.

More than happy to chat through this!