### PR TITLE
Add `<log-form>` element

### DIFF
--- a/src/_data/standalones.json
+++ b/src/_data/standalones.json
@@ -352,5 +352,12 @@
     "category": "design",
     "repo": "https://github.com/sakamies/conditional-elements",
     "snippet": "<input name='animal'><if- name='animal' value='Giraffe'>Giraffes are awesome!</if->"
+  },
+  {
+    "name": "log-form",
+    "repo": "https://github.com/knowler/log-form-element",
+    "category": "utilities",
+    "script": "npx jsr add @knowler/log-form-element",
+    "snippet": "<log-form><form><label>Pizza toppings <input name=pizza-toppings></label><button>Submit</button></form></log-form>"
   }
 ]


### PR DESCRIPTION
[`<log-form>`](https://github.com/knowler/log-form-element) is a very simple custom element I made for debugging forms. Just wrap a form with it and open the console. All form submissions will be logged instead of the default form action.

I personally just use ESM, but I figured I’d add it to a package registry to make it easier to consume: [`@knowler/log-form-element` on JSR](https://jsr.io/@knowler/log-form-element). For the `script` field, I’ve added the `npx` command that works with JSR (i.e. it uses the `jsr` package to add JSR as a registry in `.npmrc` and then adds the package as a dependency in `package.json`).