### PR TITLE
Update link to pwa-install

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ Frequently-solved problems in web component form.
 - [`<katex-display>`](https://github.com/justinfagnani/katex-elements)
 - [`<no-spoilers>`](https://github.com/andrico1234/no-spoilers)
 - [`<place-holder>`](https://github.com/Noleli/place-holder)
-- [`<pwa-install>`](https://github.com/pwa-builder/pwa-install)
+- [`<pwa-install>`](https://github.com/khmyznikov/pwa-install)
 
 ## Novelty Elements
 

--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ Frequently-solved problems in web component form.
 - [`<katex-display>`](https://github.com/justinfagnani/katex-elements)
 - [`<no-spoilers>`](https://github.com/andrico1234/no-spoilers)
 - [`<place-holder>`](https://github.com/Noleli/place-holder)
-- [`<pwa-install>`](https://github.com/khmyznikov/pwa-install)
+- [`<pwa-install>`](https://github.com/pwa-builder/pwa-install)
 
 ## Novelty Elements
 

--- a/src/_data/standalones.json
+++ b/src/_data/standalones.json
@@ -92,7 +92,7 @@
   {
     "name": "pwa-install",
     "category": "custom",
-    "repo": "https://github.com/pwa-builder/pwa-install"
+    "repo": "https://github.com/khmyznikov/pwa-install"
   },
   {
     "name": "l-i",

--- a/src/_data/standalones.json
+++ b/src/_data/standalones.json
@@ -332,7 +332,7 @@
     "url": "https://darn.es/play-button-web-component",
     "script": "npm install @daviddarnes/play-button",
     "snippet": "<play-button><button>Play me</button><audio src='...'></audio></play-button>"
-  }, 
+  },
   {
     "name": "youtube-player",
     "repo": "https://github.com/alanwsmith/youtube-player.alanwsmith.com",


### PR DESCRIPTION
[pwa-builder/pwa-install](https://github.com/pwa-builder/pwa-install) is marked as archived, if you follow the link to the main pwa-builder repo and onwards to the pwa-install component, the org is now khmyznikov/pwa-install