### PR TITLE
Add tabs- element

### DIFF
--- a/src/_data/standalones.json
+++ b/src/_data/standalones.json
@@ -411,5 +411,11 @@
     "url": "https://slide-deck.netlify.app/",
     "script": "npm install @oddbird/slide-deck",
     "snippet": "<slide-deck><header><h1>This is a slide show</h1></header><div><h2>Each child is a slide</h2></div></slide-deck>"
+  },
+  {
+    "name": "tabs-",
+    "category": "extensions",
+    "repo": "https://github.com/sakamies/tabs-customelement",
+    "snippet": "<tabs-><button value=\"a\">Tab A</button></tabs-><div id=\"a\">Tab Panel A</div>"
   }
 ]


### PR DESCRIPTION
There's already the [`<tab-container>`](https://github.com/github/tab-container-element) element by github so I'm a bit hesitant to add to the list, but this [`<tabs->`](https://github.com/sakamies/tabs-customelement) is a bit simpler to use and like an order of magnitude smaller.