### PR TITLE
Add `<lazy-modal>` element

### DIFF
--- a/src/_data/standalones.json
+++ b/src/_data/standalones.json
@@ -411,5 +411,11 @@
     "url": "https://slide-deck.netlify.app/",
     "script": "npm install @oddbird/slide-deck",
     "snippet": "<slide-deck><header><h1>This is a slide show</h1></header><div><h2>Each child is a slide</h2></div></slide-deck>"
+  },
+  {
+    "name": "lazy-modal",
+    "category": "extensions",
+    "repo": "https://github.com/nonsalant/lazy-modal",
+    "snippet": "<lazy-modal popover triggers='.my-trigger' inner-styles='../example.css' inner-scripts='../example.js' close-button><!-- HTML goes here --></lazy-modal>"
   }
 ]


### PR DESCRIPTION
A popover modal that starts loading related assets (and, optionally, the content inside) when you hover or focus its trigger button(s).

- Repo: https://github.com/nonsalant/lazy-modal
- Demo: https://codepen.io/nonsalant/pen/MYwjvoo